### PR TITLE
fix: prefix all functions with back-slash

### DIFF
--- a/src/RuleSets/ExtendedPERSet.php
+++ b/src/RuleSets/ExtendedPERSet.php
@@ -91,7 +91,7 @@ final class ExtendedPERSet implements RuleSet
                     NativeFunctionInvocationFixer::SET_INTERNAL,
                     NativeFunctionInvocationFixer::SET_COMPILER_OPTIMIZED,
                 ],
-                'scope' => 'namespaced',
+                'scope' => 'all',
                 'strict' => true,
             ],
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced the rule set to apply more broadly by changing the scope parameter from 'namespaced' to 'all'. This allows for more comprehensive rule application across different contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->